### PR TITLE
Add how to install valgrind and clang-format on CONTRIBUTING.md #159

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,11 +94,7 @@ After installing valgrind and clang-format, you can use the following commands:
 
 - `make valgrind`: This command runs the project with valgrind to detect memory issues and errors.
 
-<link rel="stylesheet" type="text/css" href="warning.css">
-
-<div class="warning">
-    <p><strong>Warning:</strong> It is recommended to run `make format` and `make valgrind` before committing or making pull requests to ensure consistent formatting and identify any potential memory issues in the code.</p>
-</div>
+#### It is recommended to run `make format` and `make valgrind` before committing or making pull requests to ensure consistent formatting and identify any potential memory issues in the code.
 
 ## Before your PR
 

--- a/warning.css
+++ b/warning.css
@@ -1,7 +1,0 @@
-.warning {
-    background-color: #ffe8e8;
-    border: 1px solid #ff7f7f;
-    padding: 10px;
-    border-radius: 4px;
-    color: #ff0000;
-}

--- a/warning.css
+++ b/warning.css
@@ -1,0 +1,7 @@
+.warning {
+    background-color: #ffe8e8;
+    border: 1px solid #ff7f7f;
+    padding: 10px;
+    border-radius: 4px;
+    color: #ff0000;
+}


### PR DESCRIPTION
- Added it to "Local Development" section in CONTRIBUTING.md;
- Removed how to install valgrind/clang-format from main README.
- Explained that `make valgrind` and `make format` must always be run before committing/making PRs.